### PR TITLE
fix to build with libncuses5

### DIFF
--- a/mdport.c
+++ b/mdport.c
@@ -29,6 +29,9 @@
     SUCH DAMAGE.
 */
 
+//libncuses5 compatibility
+#define NCURSES_INTERNALS
+
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Without this fix, make fail with the following error: mdport.c:264:17: error: dereferencing pointer to incomplete type ‘TERMINAL {aka struct term}’