### PR TITLE
change CFLAGS to compile on Linux

### DIFF
--- a/configure
+++ b/configure
@@ -2692,13 +2692,13 @@ if test "$ac_test_CFLAGS" = set; then
   CFLAGS=$ac_save_CFLAGS
 elif test $ac_cv_prog_cc_g = yes; then
   if test "$GCC" = yes; then
-    CFLAGS="-g -O2"
+    CFLAGS="-g -O2 -std=gnu89"
   else
     CFLAGS="-g"
   fi
 else
   if test "$GCC" = yes; then
-    CFLAGS="-O2"
+    CFLAGS="-O2 -std=gnu89"
   else
     CFLAGS=
   fi


### PR DESCRIPTION
- **change CFLAGS to compile on Linux**
I included the `-std=gnu89` flag to ensure it compiles.
